### PR TITLE
Remove object.d from this library

### DIFF
--- a/src/d/object.d
+++ b/src/d/object.d
@@ -1,6 +1,0 @@
-// The DMD frontent currently requires a file named object.d to be imported.  So
-// this file exists to fulfill that requirement. It is hoped that DMD can be modified
-// in the fugure to no longer have such an arbitrary requirement.
-module object;
-
-public import types;

--- a/test/HelloWorld/run.d
+++ b/test/HelloWorld/run.d
@@ -5,14 +5,15 @@ import std.stdio;
 void main(string[] args)
 {
     immutable objFile = "main.o";
-    auto compile = 
+    auto compile =
     [
         "dmd"
         , "-conf="
         , "-debuglib="
         , "-defaultlib="
         , "-fPIC"
-        , "-I=../../src/d"
+        , "-I=./src"
+        , "-I=../../src/"
         , "-c"
         , "-lib"
         , "src/main.d"
@@ -21,7 +22,13 @@ void main(string[] args)
     auto compileResult = compile.execute();
     scope(exit)
     {
-        objFile.remove();
+        if (objFile.exists())
+            objFile.remove();
+    }
+    if (compileResult.status != 0)
+    {
+        writeln(compileResult.output);
+        return;
     }
 
     immutable exeFile = "main";
@@ -34,11 +41,17 @@ void main(string[] args)
     auto linkResult = link.execute();
     scope(exit)
     {
-        exeFile.remove();
+        if (exeFile.exists())
+            exeFile.remove();
+    }
+    if (linkResult.status != 0)
+    {
+        writeln(compileResult.output);
+        return;
     }
 
     auto run = ["./main"];
     auto runResult = run.execute();
 
-    assert(runResult.output == "Hello, World!\n");
+    assert(runResult.status == 0 && runResult.output == "Hello, World!\n");
 }

--- a/test/HelloWorld/src/main.d
+++ b/test/HelloWorld/src/main.d
@@ -1,5 +1,7 @@
 module main;
 
+import d.types;  // for `string`
+
 private extern(C) void __d_sys_exit(long arg1)
 {
     asm

--- a/test/HelloWorld/src/object.d
+++ b/test/HelloWorld/src/object.d
@@ -1,0 +1,3 @@
+// The DMD frontent currently requires a file named object.d to be imported.  So
+// this file exists to fulfill that requirement.
+module object;


### PR DESCRIPTION
In https://github.com/dlang/dmd/pull/9814, I failed to convince the powers-that-be that we should not be importing anything automatically.  Their opinion is that the pay-as-you-go opt-in continuum is achieved through templating.  Through that PR, though, I was able to elicit more details about  @andrealex's vision for a pay-as-you-go opt-in continuum.

From what I understand from his comments, everything fundamental to the language (i.e. druntime) would need to be a template.  druntime would be imported automatically, by automatically importing object.d, and users would opt-in to a language feature by either explicitly instantiating a template or by using a language feature that lowers to a template instantiation.

I envision utiliD as something that druntime could potentially utilize in its implementation.  For example, druntime's object.d may import utiliD for its implementation.  Therefore, object.d does not belong here.  It will still be required, however, for some tests, so those tests that need it will need to include an empty object.d in their import path to get a build.